### PR TITLE
Wip parser

### DIFF
--- a/inc/cub3d.h
+++ b/inc/cub3d.h
@@ -37,25 +37,34 @@ enum e_direction
 	WE = 2,
 	EA = 3,
 };
+typedef struct s_color
+{
+	int	r;
+	int	g;
+	int	b;
+}	t_color;
+
+/**
+ * Holds Information about the Position of the Player in the Level
+ * @param x Refers to the east / west Position of the Player
+ * @param y Refers to the up / down Position of the Player, always 0
+ * @param z Refers to the north / south Position of the Player
+ */
+typedef struct s_player
+{
+	float				x;
+	float				y;
+	float				z;
+	enum e_direction	direction;
+}	t_player;
 
 typedef struct s_scene_description
 {
-	char	*textures[4];
-	struct s_color
-	{
-		int			r;
-		int			g;
-		int			b;
-	}	floor_color;
-	struct s_color	ceiling_color;
-	char			**map_content;
-	struct s_player
-	{
-		float				x;
-		float				y;
-		float				z;
-		enum e_direction	direction;
-	}	player;
+	char		*textures[4];
+	t_color 	floor_color;
+	t_color 	ceiling_color;
+	char		**map_content;
+	t_player	player;
 }	t_scene_description;
 
 typedef struct s_game

--- a/inc/cub3d.h
+++ b/inc/cub3d.h
@@ -30,7 +30,7 @@ int     rgba(int r, int g, int b, int a);
 
 /* Parser */
 
-enum e_texture_iterator
+enum e_direction
 {
 	NO = 0,
 	SO = 1,
@@ -49,6 +49,13 @@ typedef struct s_scene_description
 	}	floor_color;
 	struct s_color	ceiling_color;
 	char			**map_content;
+	struct s_player
+	{
+		float				x;
+		float				y;
+		float				z;
+		enum e_direction	direction;
+	}	player;
 }	t_scene_description;
 
 typedef struct s_game

--- a/inc/cub3d.h
+++ b/inc/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: tschmitt <tschmitt@student.42heilbronn.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/06 15:04:41 by shaas             #+#    #+#             */
-/*   Updated: 2022/08/02 13:34:59 by tschmitt         ###   ########.fr       */
+/*   Updated: 2022/08/21 16:55:00 by tschmitt         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,13 @@ enum e_direction
 	WE = 2,
 	EA = 3,
 };
+
+enum e_grid
+{
+	X = 0,
+	Y = 1
+};
+
 typedef struct s_color
 {
 	int	r;
@@ -52,9 +59,7 @@ typedef struct s_color
  */
 typedef struct s_player
 {
-	float				x;
-	float				y;
-	float				z;
+	int					position[2];
 	enum e_direction	direction;
 }	t_player;
 

--- a/inc/parser.h
+++ b/inc/parser.h
@@ -52,6 +52,7 @@ int		set_ceiling_color(
 bool	free_map_return(char *map[], bool return_value);
 void	print_error_exit(char *error_message, int exit_code, void *to_free);
 bool	is_in_map(const char *line);
+bool	has_player(char *line);
 
 
 char	**get_scene_file_content(const char *scene_file_path);

--- a/src/parser/get_scene_description/set_map_from_content.c
+++ b/src/parser/get_scene_description/set_map_from_content.c
@@ -6,7 +6,7 @@
 /*   By: tschmitt <tschmitt@student.42heilbronn.    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/08 22:42:22 by tschmitt          #+#    #+#             */
-/*   Updated: 2022/08/08 22:42:54 by tschmitt         ###   ########.fr       */
+/*   Updated: 2022/08/21 16:57:00 by tschmitt         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,7 +58,7 @@ static inline enum e_direction	get_direction(char player_pos)
 static void	get_player(
 		t_scene_description *scene_desc,
 		char *line,
-		int z
+		int y
 		)
 {
 	int	line_iterator;
@@ -69,9 +69,8 @@ static void	get_player(
 		if (line[line_iterator] == 'N' || line[line_iterator] == 'S' \
 		|| line[line_iterator] == 'E' || line[line_iterator] == 'W')
 		{
-			scene_desc->player.x = line_iterator;
-			scene_desc->player.y = 0;
-			scene_desc->player.z = z;
+			scene_desc->player.position[X] = line_iterator;
+			scene_desc->player.position[Y] = y;
 			scene_desc->player.direction = get_direction(line[line_iterator]);
 			break ;
 		}

--- a/src/parser/get_scene_description/set_map_from_content.c
+++ b/src/parser/get_scene_description/set_map_from_content.c
@@ -49,10 +49,11 @@ static inline enum e_direction	get_direction(char player_pos)
 }
 
 /**
- * Sets the Position of the Player in the Level
- * @details X refers to the horizontal Position, east west
- * @details Y refers to the vertical Position, up down
- * @details Z refers to the depth Position, north east
+ * Sets the Position of the Player
+ * @param line The Line where the Player was found
+ * @param z North South Position of Player
+ * @arg line_iterator Iterates the line
+ *		Corresponding to the West East Position of the Player,
  */
 static void	get_player(
 		t_scene_description *scene_desc,
@@ -60,20 +61,21 @@ static void	get_player(
 		int z
 		)
 {
-	int	i;
+	int	line_iterator;
 
-	i = 0;
-	while (line[i] != '\0')
+	line_iterator = 0;
+	while (line[line_iterator] != '\0')
 	{
-		if (line[i] == 'N' || line[i] == 'S' || line[i] == 'E' || line[i] == 'W')
+		if (line[line_iterator] == 'N' || line[line_iterator] == 'S' \
+		|| line[line_iterator] == 'E' || line[line_iterator] == 'W')
 		{
-			scene_desc->player.x = i;
+			scene_desc->player.x = line_iterator;
 			scene_desc->player.y = 0;
 			scene_desc->player.z = z;
-			scene_desc->player.direction = get_direction(line[i]);
+			scene_desc->player.direction = get_direction(line[line_iterator]);
 			break ;
 		}
-		i += 1;
+		line_iterator += 1;
 	}
 }
 

--- a/src/parser/get_scene_description/set_map_from_content.c
+++ b/src/parser/get_scene_description/set_map_from_content.c
@@ -35,6 +35,42 @@ static char	*get_valid_map_line(char *map_line)
 	return (valid_line);
 }
 
+static inline enum e_direction	get_direction(char player_pos)
+{
+	if (player_pos == 'N')
+		return (NO);
+	if (player_pos == 'S')
+		return (SO);
+	if (player_pos == 'E')
+		return (EA);
+	if (player_pos == 'W')
+		return (WE);
+	return (-1);
+}
+
+static void	get_player(
+		t_scene_description *scene_desc,
+		char *line,
+		int z
+		)
+{
+	int	i;
+
+	i = 0;
+	while (line[i] != '\0')
+	{
+		if (line[i] == 'N' || line[i] == 'S' || line[i] == 'E' || line[i] == 'W')
+		{
+			scene_desc->player.x = 0;
+			scene_desc->player.y = i;
+			scene_desc->player.z = z;
+			scene_desc->player.direction = get_direction(line[i]);
+			break ;
+		}
+		i += 1;
+	}
+}
+
 int	set_map_from_content(
 		char **scene_content,
 		t_scene_description *scene_desc
@@ -49,6 +85,8 @@ int	set_map_from_content(
 	i = 0;
 	while (scene_content[i] != NULL)
 	{
+		if (has_player(scene_content[i]))
+			get_player(scene_desc, scene_content[i], i);
 		scene_desc->map_content[i] = get_valid_map_line(scene_content[i]);
 		if (scene_desc->map_content[i] == NULL)
 			return (print_error_return(ALLOC_ERROR, 1));

--- a/src/parser/get_scene_description/set_map_from_content.c
+++ b/src/parser/get_scene_description/set_map_from_content.c
@@ -48,6 +48,12 @@ static inline enum e_direction	get_direction(char player_pos)
 	return (-1);
 }
 
+/**
+ * Sets the Position of the Player in the Level
+ * @details X refers to the horizontal Position, east west
+ * @details Y refers to the vertical Position, up down
+ * @details Z refers to the depth Position, north east
+ */
 static void	get_player(
 		t_scene_description *scene_desc,
 		char *line,
@@ -61,8 +67,8 @@ static void	get_player(
 	{
 		if (line[i] == 'N' || line[i] == 'S' || line[i] == 'E' || line[i] == 'W')
 		{
-			scene_desc->player.x = 0;
-			scene_desc->player.y = i;
+			scene_desc->player.x = i;
+			scene_desc->player.y = 0;
 			scene_desc->player.z = z;
 			scene_desc->player.direction = get_direction(line[i]);
 			break ;

--- a/src/parser/has_valid_map/has_valid_map.c
+++ b/src/parser/has_valid_map/has_valid_map.c
@@ -27,7 +27,7 @@ static bool	is_open_wall(char *map[], int i)
 	return (false);
 }
 
-static inline bool	has_player(char *line)
+bool	has_player(char *line)
 {
 	if (ft_strchr(line, 'N') == NULL && ft_strchr(line, 'S') == NULL \
 	&& ft_strchr(line, 'E') == NULL && ft_strchr(line, 'W') == NULL)


### PR DESCRIPTION
Please review if the way I am getting and setting the Player Position makes sense, or if I should change it.
Currently the Position has X Y Z and Direction Propertys.

**Currently** the **Player Position** is **relative to the Level**, not the Map, but **stored** in the **Scene Description Struct**. Should there be a separate Player Position in the Game Struct which is relative to the Level and a Player Position in the Scene Description Struct, which is relative to the Map and if so where should I "convert" these Values from the Scene Description Struct to the Game Struct?


### X Y Z Relative to the Level:
**X: East / West Position** (relative to the Level, so if you control the Player Position A (Left-Arrow) and D (Right-Arrow) would change the X Property)
**Y: Up / Down Position** (should be always 0 since the Player cannot move horizontally)
**Z: North / South Position** (relative to the Level, so if you control the Player Position W (Up-Arrow) and S (Down-Arrow) would change the Z Property)


### X Y Z Relative to the Map would be different:
**X: West / East Position** (relative to the Level, so _X_ would correspond to the _Character of the Line_ of the Map in the Scene Description FIle, in other words if you would Iterate the Map as an 2D Array, _X_ would be _j_)
**Y: North / South Position** (relative to the Map, so _Y_ would correspond to the _Line of the Map_ in the Scene Description File, in other words if you would iterate the Map as an 2D Array, _Y_ would be _i_)
**Z: No use for Z** since a 2D Map file has no depth..